### PR TITLE
Fix #12: Fix 404 Error for GitHub Link, Correct Timestamp Display, and Update Post-Login Redirect to Generate URL Page

### DIFF
--- a/app.py
+++ b/app.py
@@ -127,7 +127,7 @@ def signUp():
         else:
             return render_template("signup.html", userID="Your User ID")
     else:
-        return redirect("/stats")
+        return redirect("/generateurl")
 
 
 @app.route("/login", methods=["GET", "POST"])
@@ -138,7 +138,7 @@ def logIn():
             userID = request.form["userid"]
             userPresent = usersColl.find_one({"UserID": userID})
             if userPresent:
-                output = redirect("/stats")
+                output = redirect("/generateurl")
                 resp = make_response(output)
                 expiration_date = datetime.now() + timedelta(days=30)
                 expiration_timestamp = expiration_date.timestamp()
@@ -149,13 +149,13 @@ def logIn():
         else:
             return render_template("login.html")
     else:
-        return redirect("/stats")
+        return redirect("/generateurl")
 
 
 @app.route("/", methods=["GET", "POST"])
 def home():
     if usersColl.find_one({"UserID": request.cookies.get("userID")}) != None:
-        return redirect("/stats")
+        return redirect("/generateurl")
     else:
         response = make_response(render_template("index.html"))
         if request.cookies.get("userID") != None:

--- a/app.py
+++ b/app.py
@@ -45,6 +45,9 @@ from os import environ
 from random import choice as randchoice
 from string import ascii_letters, digits, punctuation
 
+# ? Pytz --> For handling timezone
+from pytz import timezone
+
 # endregion
 #! --------------------------------------------------
 #! --------------------------------------------------
@@ -196,7 +199,7 @@ def generateurl():
                         custom_url=customURL,
                         error_url_statement="URL cannot be shortened. Please try again.",
                     )
-            now = datetime.now()
+            now = datetime.now(timezone("Asia/Kolkata"))
             id = URLsColl.count_documents({}) + 1
             time = now.strftime("%d/%m/%Y %H:%M:%S")
             userID = request.cookies.get("userID")

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ packaging==24.1
 pymongo==4.10.1
 python-dotenv==1.0.1
 Werkzeug==3.0.5
+pytz==2024.1  

--- a/templates/404.html
+++ b/templates/404.html
@@ -9,7 +9,7 @@
 </div>
 <p class="text-blue-200"><a href="https://github.com/averageblank/urlshortener" class="underline"
     target="_blank">Github</a>. Developed By
-  <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+  <a href="https://github.com/AvgBlank" target="_blank" class="underline">AvgBlank</a> and <a
     href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
 </p>
 {%endblock%}

--- a/templates/generateurl.html
+++ b/templates/generateurl.html
@@ -55,7 +55,7 @@
     </svg>Logout</a>
   <p class="text-blue-200 text-center px-2"><a href="https://github.com/averageblank/urlshortener" class="underline"
       target="_blank">Github</a>. Developed By
-    <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+    <a href="https://github.com/AvgBlank" target="_blank" class="underline">AvgBlank</a> and <a
       href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
   </p>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 </div>
 <p class="text-blue-200 text-center px-2"><a href="https://github.com/averageblank/urlshortener" class="underline"
         target="_blank">Github</a>. Developed By
-    <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+    <a href="https://github.com/AvgBlank" target="_blank" class="underline">AverageBlank</a> and <a
         href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
 </p>
 {%endblock%}

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,7 +17,7 @@
 </div>
 <p class="text-blue-200 text-center px-2"><a href="https://github.com/averageblank/urlshortener" class="underline"
         target="_blank">Github</a>. Developed By
-    <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+    <a href="https://github.com/AvgBlank" target="_blank" class="underline">AvgBlank</a> and <a
         href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
 </p>
 {%endblock%}

--- a/templates/login.html
+++ b/templates/login.html
@@ -16,7 +16,7 @@
 </div>
 <p class="text-blue-200"><a href="https://github.com/averageblank/urlshortener" class="underline"
     target="_blank">Github</a>. Developed By
-  <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+  <a href="https://github.com/AvgBlank" target="_blank" class="underline">AvgBlank</a> and <a
     href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
 </p>
 {%endblock%}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -28,7 +28,7 @@
 </div>
 <p class="text-blue-200"><a href="https://github.com/averageblank/urlshortener" class="underline"
     target="_blank">Github</a>. Developed By
-  <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+  <a href="https://github.com/AvgBlank" target="_blank" class="underline">AvgBlank</a> and <a
     href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
 </p>
 {% endblock %} {%block script %}

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -24,7 +24,7 @@
     Please copy your UserID! This will be used whenever you try to login<br />
     Once you lose it, you cannot retrieve it!
   </p>
-  <a href="/stats" class="underline text-zinc-400" id="Proceedtomainpage">Proceed to Main Page →</a>
+  <a href="/generateurl" class="underline text-zinc-400" id="Proceedtomainpage">Proceed to Main Page →</a>
 </div>
 <p class="text-blue-200"><a href="https://github.com/averageblank/urlshortener" class="underline"
     target="_blank">Github</a>. Developed By

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -63,7 +63,7 @@
     </svg>Logout</a>
   <p class="text-blue-200 text-center px-2"><a href="https://github.com/averageblank/urlshortener" class="underline"
       target="_blank">Github</a>. Developed By
-    <a href="https://github.com/AverageBlank" target="_blank" class="underline">AverageBlank</a> and <a
+    <a href="https://github.com/AvgBlank" target="_blank" class="underline">AvgBlank</a> and <a
       href="https://github.com/AalokeCode" target="_blank" class="underline">AalokeCode</a>
   </p>
 </div>


### PR DESCRIPTION
**This PR addresses several issues and implements enhancements for improved usability:**

- Fixed 404 Error for GitHub Link: Resolved the broken link to the GitHub account for AverageBlack, which was previously returning a 404 error.

- Corrected Timestamp Display: Updated the timestamp formatting to ensure accurate display for link creation times.

- Enhanced Navigation Flow: Modified the navigation flow so that, after signing up or logging in, users are now redirected to the "generateurl" page directly. This creates a smoother and more intuitive user experience.

Closes #12 