### PR TITLE
Bug fix: Logo Visibility Enhancement in Desktop View

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="shortcut icon" href="/static/images/favicon.svg" />
-  <title>{%block title %} {% endblock %} - trim.lol</title>
+  <title>{% block title %} {% endblock %} - trim.lol</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -23,10 +23,10 @@
   </style>
 </head>
 
-<body class="h-full w-full bg-zinc-950">
+<body class="h-full w-full bg-zinc-950 flex justify-center items-center">
   <div
-    class="flex justify-center items-center gap-3 md:gap-7 2xl:gap-10 flex-col w-full h-full bg-[url('static/images/bg-gradient.png')] bg-top text-white">
-    <a href="/"><img src="static/images/logo.svg" class="w-56 pb-3" /></a>
+    class="flex justify-center items-center gap-3 md:gap-7 2xl:gap-10 flex-col w-full h-full pt-10 sm:pt-20 bg-[url('static/images/bg-gradient.png')] bg-top bg-no-repeat bg-cover text-white">
+    <a href="/" class="pt-4 sm:pt-8"><img src="static/images/logo.svg" class="w-56 pb-3" /></a>
     {% block content %} {% endblock %}
   </div>
   {% block script %} {% endblock %}


### PR DESCRIPTION
Previously,  **Trim-lol** logo isn't clearly visible in the desktop view
![Screenshot 2024-10-27 104008](https://github.com/user-attachments/assets/b6ebcc95-7f3f-46c9-b116-28d34caa0eeb)
After fixing **CSS** in Base.html file 

- Added pt-10 sm:pt-20
- bg-no-repeat and bg-cover
- Centered Flex Alignment

![Screenshot 2024-10-28 181546](https://github.com/user-attachments/assets/25c2b156-5c61-4245-9e08-dd2bf16e32e9)
