### PR TITLE
Fix #15: Add feature to delete URL history 

### DIFF
--- a/app.py
+++ b/app.py
@@ -360,6 +360,26 @@ def stats():
         return response
 
 
+
+@app.route("/delete", methods=["POST"])
+def delete():
+    userID = request.cookies.get("userID")
+    if usersColl.find_one({"UserID": userID}) is not None:
+        data = request.get_json()
+        shortened_url = data.get("shortened_url")
+        
+        if shortened_url:
+            URLsColl.delete_one({"ShortenedURL": shortened_url, "UserID": userID})
+            return redirect(url_for("stats"))  # Redirect to refresh list
+        return "Shortened URL not found.", 400  # Bad Request if no URL provided
+    else:
+        response = make_response(redirect("/"))
+        response.set_cookie("userID", "", expires=0)
+        return response
+
+
+
+
 @app.route("/<id>")
 @app.route("/<id>/")
 def url_redirection(id):

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -154,7 +154,7 @@
   
   async function deletecontent(button) {
     const shortenedUrl = button.dataset.msg;
-
+    if(confirm(`Are you sure you want to delete https://trim.lol/ ${shortenedUrl}`)){
     try {
       const response = await fetch('/delete', {
         method: 'POST',
@@ -175,6 +175,7 @@
       console.error(error);
       alert(error.message);
     }
+  }
   }
 
 

--- a/templates/stats.html
+++ b/templates/stats.html
@@ -74,6 +74,19 @@
                 ></path>
               </svg>
             </button>
+
+            <button class="text-white bg-red-600 flex items-center gap-2 hover:bg-red-700 p-2 rounded-lg delete-button" 
+              onclick="deletecontent(this)" 
+              data-msg="{{url['ShortenedURL']}}"
+              >Delete
+              <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" class="fill-white" viewBox="0 0 256 256">
+                <path
+                  d="M216,72H184V56a16,16,0,0,0-16-16H88A16,16,0,0,0,72,56V72H40a8,8,0,0,0,0,16H56v136a16,16,0,0,0,16,16H184a16,16,0,0,0,16-16V88h16a8,8,0,0,0,0-16ZM88,56h80V72H88ZM184,224H72V88H184Z">
+                </path>
+                </svg>
+            </button>
+
+
           </td>
           <td class="px-6 py-4">{{url['Timestamp']}}</td>
           <td class="px-6 py-4">{{url['Clicks']}}</td>
@@ -137,5 +150,35 @@
       console.error("Failed to copy: ", err);
     }
   };
+
+  
+  async function deletecontent(button) {
+    const shortenedUrl = button.dataset.msg;
+
+    try {
+      const response = await fetch('/delete', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify({ shortened_url: shortenedUrl })
+      });
+
+      if (!response.ok) {
+        const message = await response.text();
+        throw new Error(message || 'An error occurred while deleting the URL.');
+      }
+
+      // Redirect to stats page on success
+      window.location.href = "{{ url_for('stats') }}";
+    } catch (error) {
+      console.error(error);
+      alert(error.message);
+    }
+  }
+
+
+
+
 </script>
 {%endblock%}


### PR DESCRIPTION
This merge request implements the "Delete URL Shortening History" feature, allowing users to manage their URL shortening history by deleting individual entries
![Screenshot 2024-10-27 103659](https://github.com/user-attachments/assets/62990d6f-176f-40a8-a4a2-342307ed2ded)
Added a "Delete" button next to each URL entry in the Statistics, enabling users to delete specific entries.
![Screenshot 2024-10-29 235727](https://github.com/user-attachments/assets/f8ade686-9feb-45f5-a6b9-13456bae90c2)
"Fixes: #15 "